### PR TITLE
Add basic JointJS preview panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the README for your extension "joint-js". After writing up a brief descr
 
 ## Features
 
-Describe specific features of your extension including screenshots of your extension in action. Image paths are relative to this README file.
+* **JointJS Preview** - Run the `Show JointJS Preview` command to open a webview displaying a sample JointJS diagram.
 
 For example if there is an image subfolder under your extension project workspace:
 

--- a/extension.js
+++ b/extension.js
@@ -17,14 +17,58 @@ function activate(context) {
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with  registerCommand
 	// The commandId parameter must match the command field in package.json
-	let disposable = vscode.commands.registerCommand('joint-js.helloWorld', function () {
-		// The code you place here will be executed every time your command is executed
+    let disposable = vscode.commands.registerCommand('joint-js.helloWorld', function () {
+        vscode.window.showInformationMessage('Hello World from Joint Js vsCode!');
+    });
 
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from Joint Js vsCode!');
-	});
+    let previewDisposable = vscode.commands.registerCommand('joint-js.showPreview', function () {
+        const panel = vscode.window.createWebviewPanel(
+            'jointJsPreview',
+            'JointJS Preview',
+            vscode.ViewColumn.Beside,
+            { enableScripts: true }
+        );
+        panel.webview.html = getWebviewContent();
+    });
 
-	context.subscriptions.push(disposable);
+    context.subscriptions.push(disposable, previewDisposable);
+}
+
+function getWebviewContent() {
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>JointJS Preview</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/backbone.js/1.4.1/backbone-min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jointjs/3.7.2/joint.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jointjs/3.7.2/joint.min.css" />
+    <style>body{padding:0;margin:0;}#paper{width:100%;height:100vh;}</style>
+</head>
+<body>
+    <div id="paper"></div>
+    <script>
+        const graph = new joint.dia.Graph();
+        const paper = new joint.dia.Paper({
+            el: document.getElementById('paper'),
+            model: graph,
+            width: document.body.clientWidth,
+            height: document.body.clientHeight,
+            gridSize: 10
+        });
+
+        const rect = new joint.shapes.standard.Rectangle();
+        rect.position(50, 50);
+        rect.resize(100, 40);
+        rect.attr({
+            body: { fill: 'blue' },
+            label: { text: 'Hello', fill: 'white' }
+        });
+        rect.addTo(graph);
+    </script>
+</body>
+</html>`;
 }
 
 // this method is called when your extension is deactivated

--- a/package.json
+++ b/package.json
@@ -9,16 +9,21 @@
 	"categories": [
 		"Other"
 	],
-	"activationEvents": [
-        "onCommand:joint-js.helloWorld"
-	],
+        "activationEvents": [
+        "onCommand:joint-js.helloWorld",
+        "onCommand:joint-js.showPreview"
+        ],
 	"main": "./extension.js",
 	"contributes": {
-		"commands": [{
+                "commands": [{
             "command": "joint-js.helloWorld",
             "title": "Hello World"
+                },
+                {
+            "command": "joint-js.showPreview",
+            "title": "Show JointJS Preview"
 
-		}]
+                }]
 	},
 	"scripts": {
         "lint": "eslint .",


### PR DESCRIPTION
## Summary
- implement `joint-js.showPreview` command
- add webview panel that displays a sample JointJS diagram
- document preview command in README

## Testing
- `npm test` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6840fb4639c88332b6df2885c17b1238